### PR TITLE
chore: fix duplicate realm names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,7 @@ local-setup:
 .PHONY: dev-setup
 dev-setup:
 	docker-compose -f dockerfiles/keycloak-postgres.yml up
+
+.PHONY: dev-setup-multi
+dev-setup-multi:
+	docker-compose -f dockerfiles/keycloak-postgres-multiple.yml up

--- a/keycloak-exports/terraform-cli.json
+++ b/keycloak-exports/terraform-cli.json
@@ -1,0 +1,86 @@
+{
+  "clientId": "terraform-cli",
+  "surrogateAuthRequired": false,
+  "enabled": true,
+  "alwaysDisplayInConsole": false,
+  "clientAuthenticatorType": "client-secret",
+  "redirectUris": [],
+  "webOrigins": [],
+  "notBefore": 0,
+  "bearerOnly": false,
+  "consentRequired": false,
+  "standardFlowEnabled": false,
+  "implicitFlowEnabled": false,
+  "directAccessGrantsEnabled": false,
+  "serviceAccountsEnabled": true,
+  "publicClient": false,
+  "frontchannelLogout": false,
+  "protocol": "openid-connect",
+  "attributes": {
+    "saml.assertion.signature": "false",
+    "saml.multivalued.roles": "false",
+    "saml.force.post.binding": "false",
+    "saml.encrypt": "false",
+    "saml.server.signature": "false",
+    "saml.server.signature.keyinfo.ext": "false",
+    "exclude.session.state.from.auth.response": "false",
+    "client_credentials.use_refresh_token": "false",
+    "saml_force_name_id_format": "false",
+    "saml.client.signature": "false",
+    "tls.client.certificate.bound.access.tokens": "false",
+    "saml.authnstatement": "false",
+    "display.on.consent.screen": "false",
+    "saml.onetimeuse.condition": "false"
+  },
+  "authenticationFlowBindingOverrides": {},
+  "fullScopeAllowed": false,
+  "nodeReRegistrationTimeout": -1,
+  "protocolMappers": [
+    {
+      "name": "Client Host",
+      "protocol": "openid-connect",
+      "protocolMapper": "oidc-usersessionmodel-note-mapper",
+      "consentRequired": false,
+      "config": {
+        "user.session.note": "clientHost",
+        "id.token.claim": "true",
+        "access.token.claim": "true",
+        "claim.name": "clientHost",
+        "jsonType.label": "String"
+      }
+    },
+    {
+      "name": "Client ID",
+      "protocol": "openid-connect",
+      "protocolMapper": "oidc-usersessionmodel-note-mapper",
+      "consentRequired": false,
+      "config": {
+        "user.session.note": "clientId",
+        "id.token.claim": "true",
+        "access.token.claim": "true",
+        "claim.name": "clientId",
+        "jsonType.label": "String"
+      }
+    },
+    {
+      "name": "Client IP Address",
+      "protocol": "openid-connect",
+      "protocolMapper": "oidc-usersessionmodel-note-mapper",
+      "consentRequired": false,
+      "config": {
+        "user.session.note": "clientAddress",
+        "id.token.claim": "true",
+        "access.token.claim": "true",
+        "claim.name": "clientAddress",
+        "jsonType.label": "String"
+      }
+    }
+  ],
+  "defaultClientScopes": ["web-origins", "role_list", "profile", "roles", "email"],
+  "optionalClientScopes": ["address", "phone", "offline_access", "microprofile-jwt"],
+  "access": {
+    "view": true,
+    "configure": true,
+    "manage": true
+  }
+}

--- a/terraform/keycloak-dev/realms/onestopauth-basic/main.tf
+++ b/terraform/keycloak-dev/realms/onestopauth-basic/main.tf
@@ -1,3 +1,3 @@
 data "keycloak_realm" "this" {
-  realm = "onestopauth"
+  realm = "onestopauth-basic"
 }

--- a/terraform/keycloak-dev/realms/onestopauth-both/main.tf
+++ b/terraform/keycloak-dev/realms/onestopauth-both/main.tf
@@ -1,3 +1,3 @@
 data "keycloak_realm" "this" {
-  realm = "onestopauth"
+  realm = "onestopauth-both"
 }

--- a/terraform/keycloak-dev/realms/onestopauth-business/main.tf
+++ b/terraform/keycloak-dev/realms/onestopauth-business/main.tf
@@ -1,3 +1,3 @@
 data "keycloak_realm" "this" {
-  realm = "onestopauth"
+  realm = "onestopauth-business"
 }

--- a/terraform/keycloak-prod/realms/onestopauth-basic/main.tf
+++ b/terraform/keycloak-prod/realms/onestopauth-basic/main.tf
@@ -1,3 +1,3 @@
 data "keycloak_realm" "this" {
-  realm = "onestopauth"
+  realm = "onestopauth-basic"
 }

--- a/terraform/keycloak-prod/realms/onestopauth-both/main.tf
+++ b/terraform/keycloak-prod/realms/onestopauth-both/main.tf
@@ -1,3 +1,3 @@
 data "keycloak_realm" "this" {
-  realm = "onestopauth"
+  realm = "onestopauth-both"
 }

--- a/terraform/keycloak-prod/realms/onestopauth-business/main.tf
+++ b/terraform/keycloak-prod/realms/onestopauth-business/main.tf
@@ -1,3 +1,3 @@
 data "keycloak_realm" "this" {
-  realm = "onestopauth"
+  realm = "onestopauth-business"
 }

--- a/terraform/keycloak-test/realms/onestopauth-basic/main.tf
+++ b/terraform/keycloak-test/realms/onestopauth-basic/main.tf
@@ -1,3 +1,3 @@
 data "keycloak_realm" "this" {
-  realm = "onestopauth"
+  realm = "onestopauth-basic"
 }

--- a/terraform/keycloak-test/realms/onestopauth-both/main.tf
+++ b/terraform/keycloak-test/realms/onestopauth-both/main.tf
@@ -1,3 +1,3 @@
 data "keycloak_realm" "this" {
-  realm = "onestopauth"
+  realm = "onestopauth-both"
 }

--- a/terraform/keycloak-test/realms/onestopauth-business/main.tf
+++ b/terraform/keycloak-test/realms/onestopauth-business/main.tf
@@ -1,3 +1,3 @@
 data "keycloak_realm" "this" {
-  realm = "onestopauth"
+  realm = "onestopauth-business"
 }


### PR DESCRIPTION
- fix duplicate realm names
- included the client export JSON, but still, need to assign target client roles to get admin privileges for target realms.
- see https://github.com/bcgov/sso_terraform/wiki/REDHAT-SSO-issue-report-regarding-%60admin-service-account%60-authorization-via-API