### PR TITLE
chore: remove terraform_validate pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,6 @@ repos:
     rev: v1.50.0
     hooks:
       - id: terraform_fmt
-      - id: terraform_validate
       - id: terraform_docs
       - id: terraform_tflint
   - repo: git://github.com/pre-commit/pre-commit-hooks

--- a/bin/terraform-init.sh
+++ b/bin/terraform-init.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+pwd="$(dirname "$0")"
+basedir="$pwd/../terraform"
+terraform init "$basedir/keycloak-dev/realms/${realm}/client-${client}.tf"
+test="$basedir/keycloak-test/realms/${realm}/client-${client}.tf"
+prod="$basedir/keycloak-prod/realms/${realm}/client-${client}.tf"

--- a/bin/terraform-init.sh
+++ b/bin/terraform-init.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-pwd="$(dirname "$0")"
-basedir="$pwd/../terraform"
-terraform init "$basedir/keycloak-dev/realms/${realm}/client-${client}.tf"
-test="$basedir/keycloak-test/realms/${realm}/client-${client}.tf"
-prod="$basedir/keycloak-prod/realms/${realm}/client-${client}.tf"


### PR DESCRIPTION
- let's remove the `terraform_validate` pre-commit hook since it causes unexpected results.