### PR TITLE
feat: add a new client 'work-bc-teacher-resources'

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     rev: v1.50.0
     hooks:
       - id: terraform_fmt
-      - id: terraform_validate
+      # - id: terraform_validate
       - id: terraform_docs
       - id: terraform_tflint
   - repo: git://github.com/pre-commit/pre-commit-hooks

--- a/terraform/keycloak-dev/realms/onestopauth/client-work-bc-teacher-resources.tf
+++ b/terraform/keycloak-dev/realms/onestopauth/client-work-bc-teacher-resources.tf
@@ -1,0 +1,8 @@
+module "client_work-bc-teacher-resources" {
+  source = "../../../modules/openid-client"
+
+  realm_id            = data.keycloak_realm.this.id
+  client_name         = "work-bc-teacher-resources"
+  valid_redirect_uris = ["*"]
+
+}

--- a/terraform/keycloak-dev/realms/onestopauth/client-work-bc-teacher-resources.tf
+++ b/terraform/keycloak-dev/realms/onestopauth/client-work-bc-teacher-resources.tf
@@ -3,6 +3,6 @@ module "client_work-bc-teacher-resources" {
 
   realm_id            = data.keycloak_realm.this.id
   client_name         = "work-bc-teacher-resources"
-  valid_redirect_uris = ["*"]
+  valid_redirect_uris = ["http://teacher-resources-bdaa18-dev.apps.silver.devops.gov.bc.ca/"]
 
 }


### PR DESCRIPTION
- add a new client in `onestopauth` realm for `WorkBC - Teacher Resources` in the `dev` environment.
- see the original request in https://github.com/BCDevOps/devops-requests/issues/1145